### PR TITLE
add config file option and generalize for any repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # binder-pr-bot
 > A GitHub App built with [Probot](https://github.com/probot/probot) that A GitHub bot generating binder links for GitHub Pull Requests
 
+## Usage
+
+1. Configure the GitHub App (TODO: add link here).
+2. Create `.github/binder.yml` based on the following template.
+3. The bot will start commenting on new Pull Requests with a link to a binder session.
+
+A `.github/binder.yml` file is required to enable this app. The file can be empty, or it can override any of these default settings:
+
+```yaml
+# Configuration for binder-pr-bot - https://github.com/ian-r-rose/binder-pr-bot
+
+# URL to BinderHub Instance
+binderHubUrl: https://mybinder.org/
+
+# Prose for the begining of each comment by the bot
+binderComment: Thanks for making a pull request to ${repo}!
+
+# Suffix to add to the end of the each binder link 
+# binderUrlSuffix: ?urlpath=lab
+
 ## Setup
 
 ```sh
@@ -16,14 +36,14 @@ npm start
 
 ## Contributing
 
-If you have suggestions for how binder-pr-bot could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
+If you have suggestions for how binder-pr-bot could be improved, or want to report a bug, open an issue! We love any and all contributions.
 
 For more, check out the [Contributing Guide](CONTRIBUTING.md).
 
 ## License
 
-[ISC](LICENSE) © 2019 Joe Hamman <jhamman@ucar.edu>
+[ISC](LICENSE) © 2019 Ian Rose <ian.r.rose@gmail.com>
 
 ## History
 
-This project was forked from Ian Rose's jupyterlab-dev-mode-bot.
+This project was originally named jupyterlab-dev-mode-bot. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# jupyterlab-dev-mode-bot
-
-> A GitHub App built with [Probot](https://github.com/probot/probot) that A GitHub bot generating binder links for JupyterLab PRs
+# binder-pr-bot
+> A GitHub App built with [Probot](https://github.com/probot/probot) that A GitHub bot generating binder links for GitHub Pull Requests
 
 ## Setup
 
@@ -17,10 +16,14 @@ npm start
 
 ## Contributing
 
-If you have suggestions for how jupyterlab-dev-mode-bot could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
+If you have suggestions for how binder-pr-bot could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
 
 For more, check out the [Contributing Guide](CONTRIBUTING.md).
 
 ## License
 
-[ISC](LICENSE) © 2019 Ian Rose <ian.r.rose@gmail.com>
+[ISC](LICENSE) © 2019 Joe Hamman <jhamman@ucar.edu>
+
+## History
+
+This project was forked from Ian Rose's jupyterlab-dev-mode-bot.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jupyterlab-dev-mode-bot",
+  "name": "binder-pr-bot",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -3067,7 +3068,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3088,12 +3090,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3108,17 +3112,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3235,7 +3242,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3247,6 +3255,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3261,6 +3270,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3268,12 +3278,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3292,6 +3304,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3372,7 +3385,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3384,6 +3398,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3469,7 +3484,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3505,6 +3521,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3524,6 +3541,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3567,12 +3585,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5390,7 +5410,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "jupyterlab-dev-mode-bot",
+  "name": "binder-pr-bot",
   "version": "1.0.0",
-  "description": "A GitHub bot generating binder links for JupyterLab PRs",
-  "author": "Ian Rose <ian.r.rose@gmail.com>",
+  "description": "A GitHub bot generating binder links for GitHub PRs",
+  "author": "Joe Hamman <jhamman@ucar.edu>",
   "license": "ISC",
-  "repository": "https://github.com//jupyterlab-dev-mode-bot.git",
-  "homepage": "https://github.com//jupyterlab-dev-mode-bot",
-  "bugs": "https://github.com//jupyterlab-dev-mode-bot/issues",
+  "repository": "https://github.com/binder-pr-bot.git",
+  "homepage": "https://github.com/binder-pr-bot",
+  "bugs": "https://github.com/binder-pr-bot/issues",
   "keywords": [
     "probot",
     "github",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,13 @@ export = (app: Application) => {
     const user = head.user.login;
     const repo = head.repo.name;
 
-    const comment = `Thanks for making a pull request to JupyterLab!
+    // Get binder url
+    const config = await context.config('config.yml', { 'binder_url': 'https://mybinder.org' })
+    const binder = config.binder_url
 
-To try out this branch on [binder](https://mybinder.org), follow this link: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${user}/${repo}/${ref}?urlpath=lab-dev)`
+    const comment = `Thanks for making a pull request to ${repo}!
+
+To try out this branch on [binder](${binder}), follow this link: [![Binder](${binder}/badge_logo.svg)](${binder}/v2/gh/${user}/${repo}/${ref})`
     const issueComment = context.issue({ body: comment })
     await context.github.issues.createComment(issueComment)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,13 @@ export = (app: Application) => {
     const repo = head.repo.name;
 
     // Get binder url
-    const config = await context.config('config.yml', { 'binder_url': 'https://mybinder.org' })
-    const binder = config.binder_url
+    const binder = await context.config('binder.yml', { 'binderHubUrl': 'https://mybinder.org' })
+    const prose = await context.config('binder.yml', { 'binderComment': `Thanks for making a pull request to ${repo}!` })
+    const suffix = await context.config('binder.yml', { 'binderUrlSuffix': '' })
 
-    const comment = `Thanks for making a pull request to ${repo}!
+    const comment = `${prose}
 
-To try out this branch on [binder](${binder}), follow this link: [![Binder](${binder}/badge_logo.svg)](${binder}/v2/gh/${user}/${repo}/${ref})`
+To try out this branch on [binder](${binder}), follow this link: [![Binder](${binder}/badge_logo.svg)](${binder}/v2/gh/${user}/${repo}/${ref}${suffix})`
     const issueComment = context.issue({ body: comment })
     await context.github.issues.createComment(issueComment)
   })


### PR DESCRIPTION
@ian-r-rose, we've chatted offline a bit but I think this is in a stable state now so I'm opening up this PR. Stable enough to give it a proper test. I have a bunch of questions:

1. As you will see below, I've renamed the bot to `binder-pr-bot` to generalize the application beyond JupyterLab. I'm wondering if you have interest in merging the two concepts or if you'd prefer I just take my fork and run. Either option is fine with me but since you put 99% of the effort in here, I'm keen to let you decide. Same goes for the authorship and contact details - I originally thought this was going to require more changes so I got ahead of myself. Happy to back those out if need be.
1. What other config options do you think would be useful? I've yet to figure out how to optionally add the `urlpath` keyword you had at first? I can see folks also wanting to customize the welcome message.
